### PR TITLE
Fix minor typo in comments and improve documentation clarity

### DIFF
--- a/contracts/src/SimpleConfidentialToken.sol
+++ b/contracts/src/SimpleConfidentialToken.sol
@@ -42,7 +42,7 @@ contract SimpleConfidentialToken {
     function transfer(address to, euint256 value) public returns (ebool success) {
         // always perform this check on encrypted parameters. In this case, a malicious caller could try to pass
         // the handle corresponding of a victim's balance to deduce its value, it wouldn't revert without this check
-        // has this token contract holds allowance on the balances of all holders.
+        // as this token contract holds allowance on the balances of all holders.
         require(msg.sender.isAllowed(value), "SimpleConfidentialToken: unauthorized value handle access");
 
         return _transfer(to, value);


### PR DESCRIPTION
- Fixed a minor typo in comments (`has this token contract holds` → `as this token contract holds`).
- Slightly improved comment phrasing for better readability and clarity.
- No functional or logic changes were made to the contract.
- Code behavior remains the same; only documentation comments were improved.