### PR TITLE
Fix React example boolean encryption handle type

### DIFF
--- a/backend/src/test/react-example/src/lib/inco.ts
+++ b/backend/src/test/react-example/src/lib/inco.ts
@@ -11,6 +11,14 @@ export const createIncoLite = async (chain: Chain, pepper: any) => {
   }
   return await Lightning.latest(pepper, chain.id as any);
 };
+const getHandleType = (value: bigint | boolean) => {
+  if (typeof value === 'boolean') {
+    return handleTypes.ebool;
+  }
+
+  return handleTypes.euint256;
+};
+
 export const encrypt = async (
   lightning: Lightning,
   privateKey: Hex,
@@ -57,7 +65,7 @@ export const encrypt = async (
     {
       accountAddress: walletClient.account.address,
       dappAddress: addTwoAddress,
-      handleType: handleTypes.euint256,
+      handleType: getHandleType(value),
     },
   );
   return ciphertext;


### PR DESCRIPTION
The React example accepts both bigint and boolean values, but always encrypted them as euint256 handles. Boolean inputs should use the ebool handle type so ciphertext metadata matches the value being encrypted.

This selects ebool for boolean values and keeps euint256 for bigint values.