### PR TITLE
fix(SimpleConfidentialToken): self-transfer mints tokens

### DIFF
--- a/contracts/src/SimpleConfidentialToken.sol
+++ b/contracts/src/SimpleConfidentialToken.sol
@@ -57,11 +57,14 @@ contract SimpleConfidentialToken {
         // if the balance is insufficient, which is equivalent to doing nothing.
         euint256 transferredValue = success.select(value, uint256(0).asEuint256());
 
-        // saving handles used multiple times in memory variables to save some gas
+        // saving handles used multiple times in memory variables to save some gas.
+        // the debit must be written to storage before the credit is computed: when `to` is the
+        // sender itself both sides alias the same slot, so reading both balances up front would
+        // make the credit overwrite the debit and mint `transferredValue` out of thin air.
         euint256 senderNewBalance = balanceOf[msg.sender].sub(transferredValue);
-        euint256 receiverNewBalance = balanceOf[to].add(transferredValue);
-
         balanceOf[msg.sender] = senderNewBalance;
+
+        euint256 receiverNewBalance = balanceOf[to].add(transferredValue);
         balanceOf[to] = receiverNewBalance;
 
         // allow the sender to see its new balance

--- a/contracts/src/test/TestSimpleConfidentialToken.t.sol
+++ b/contracts/src/test/TestSimpleConfidentialToken.t.sol
@@ -51,4 +51,18 @@ contract TestSimpleConfidentialToken is IncoTest {
         assertEq(decryptedBobBalance, 1 * GWEI);
         assertEq(decryptedAliceBalance, 9 * GWEI);
     }
+
+    // A transfer to self must be a no-op. If the debit and the credit are both computed from the
+    // pre-transfer balance, the credit overwrites the debit and the sender ends up minting tokens.
+    function testSelfTransferDoesNotMintTokens() public {
+        vm.deal(address(alice), inco.getFee());
+        // Alice sends her whole balance (10 GWEI) to herself.
+        bytes memory ciphertext = fakePrepareEuint256Ciphertext(10 * GWEI, alice, address(token));
+        vm.startPrank(alice);
+        token.transfer{value: inco.getFee()}(alice, ciphertext);
+        vm.stopPrank();
+        processAllOperations();
+
+        assertEq(getUint256Value(token.balanceOf(alice)), 10 * GWEI);
+    }
 }


### PR DESCRIPTION
## Problem

`SimpleConfidentialToken._transfer` derives both the debit and the credit from the *pre-transfer* balances, and only then writes them back:

```solidity
euint256 senderNewBalance = balanceOf[msg.sender].sub(transferredValue);
euint256 receiverNewBalance = balanceOf[to].add(transferredValue);

balanceOf[msg.sender] = senderNewBalance;
balanceOf[to] = receiverNewBalance;
```

When `to == msg.sender`, both sides alias the same storage slot. `balanceOf[to]` is still read as the pre-transfer balance `B`, so the second write overwrites the first:

- `senderNewBalance` = `B - v`
- `receiverNewBalance` = `B + v` (reads `B`, not `B - v`)
- final `balanceOf[msg.sender]` = `B + v`

The `ge` check passes for `v == B`, so any holder can double their balance by transferring their full balance to themselves, and repeat it without limit. The token's supply is unbounded and every other holder's balance is diluted.

Note this is not FHE-specific — it is plain storage aliasing — but the multiplexer pattern hides it: nothing reverts, and the balances are ciphertext handles, so the extra supply is invisible on-chain.

## Fix

Write the debit to storage before reading the receiver's balance, so a self-transfer nets to zero. This is the ordering used by OpenZeppelin's `ERC20._update`, and by `ConfidentialERC20._transfer` in [`inco-lite-template`](https://github.com/Inco-fhevm/inco-lite-template/blob/main/contracts/ConfidentialERC20.sol), which already updates the two slots sequentially. Behaviour for `to != msg.sender` is unchanged.

## Test

Added `testSelfTransferDoesNotMintTokens`: Alice sends her whole 10 GWEI balance to herself and must still hold exactly 10 GWEI.

Before the fix:

```
Ran 2 tests for src/test/TestSimpleConfidentialToken.t.sol:TestSimpleConfidentialToken
[FAIL: assertion failed: 20000000000 != 10000000000] testSelfTransferDoesNotMintTokens() (gas: 434908)
[PASS] testTransfer() (gas: 485969)
Suite result: FAILED. 1 passed; 1 failed; 0 skipped
```

After the fix:

```
Ran 2 tests for src/test/TestSimpleConfidentialToken.t.sol:TestSimpleConfidentialToken
[PASS] testSelfTransferDoesNotMintTokens() (gas: 434205)
[PASS] testTransfer() (gas: 485962)
Suite result: ok. 2 passed; 0 failed; 0 skipped
```

Both runs are `forge test` in `contracts/` against `@inco/lightning@1.0.0`, on `ubuntu-latest` with `foundry-rs/foundry-toolchain@v1`.

## Why it matters here

`SimpleConfidentialToken` is the reference confidential-token example in the DDK, and its comments are explicitly teaching the security patterns to follow (the handle-authorization check, the multiplexer pattern). Developers copy this file as their starting point, so the ordering bug propagates into downstream tokens.
