### PR TITLE
ci: run the Solidity test suite

### DIFF
--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -1,7 +1,6 @@
 [profile.default]
 src = 'src'
 test = 'src/test'
-test_match = '*.t.sol'
 no_match_path = 'src/LibTest.sol'
 allow_paths = ['../']
 evm_version = 'cancun'

--- a/package.json
+++ b/package.json
@@ -11,10 +11,11 @@
   ],
   "scripts": {
     "test:setup": "docker compose up --detach && pushd contracts && forge compile && popd",
+    "test:contracts": "pushd contracts && forge test && popd",
     "test:e2e": "bun test:setup && pushd backend && bun test:e2e && popd",
     "test:frontend:build": "bun test:setup && pushd backend && bun test:frontend:build && popd",
     "test:frontend": "bun test:setup && pushd backend/src/test/react-example && bun vitest run test/Inco.spec.tsx && popd",
-    "test": "bun test:setup && bun test:e2e && bun test:frontend && bun test:frontend:build",
+    "test": "bun test:contracts && bun test:setup && bun test:e2e && bun test:frontend && bun test:frontend:build",
     "lint": "bun prettier --check .",
     "lint:fix": "bun prettier --write ."
   },


### PR DESCRIPTION
## Problem

`contracts/src/test/TestSimpleConfidentialToken.t.sol` is compiled but never executed. `test:setup` runs `forge compile`, and no script anywhere runs `forge test`:

```
"test:setup": "docker compose up --detach && pushd contracts && forge compile && popd",
"test":       "bun test:setup && bun test:e2e && bun test:frontend && bun test:frontend:build",
```

Every one of `test:e2e`, `test:frontend` and `test:frontend:build` re-invokes `test:setup`, so a green CI run calls `forge compile` four times and `forge test` zero times. Grepping the log of the most recent green run on `main` ([run 31478643858](https://github.com/Inco-fhevm/lightning-rod/actions/runs/31478643858)) confirms it:

| | occurrences |
|---|---|
| `forge compile` | 4 |
| `forge test` | **0** |
| `Suite result:` / `Ran N tests` lines | **0** |

So the contract test suite is dead weight in CI: it type-checks, but a behavioural regression in `SimpleConfidentialToken` cannot fail the build. The README already tells contributors to run `forge test` by hand, which is the only place these tests currently execute.

## Fix

Add a `test:contracts` script and put it at the front of the `test` chain:

```
"test:contracts": "pushd contracts && forge test && popd",
"test": "bun test:contracts && bun test:setup && ..."
```

It runs first because it is the cheapest gate in the pipeline — `IncoTest` mocks the Inco infrastructure in Solidity, so this step needs no Docker daemon, no local node and no browser, and finishes in milliseconds. A broken contract now fails the build before the run spends time pulling images.

Also dropped `test_match` from `contracts/foundry.toml`. It is not a Foundry option, so it never had any effect, and it makes every `forge` invocation print:

```
Warning: Found unknown `test_match` config for profile `default` defined in foundry.toml.
```

Discovery is already scoped by `test = 'src/test'` and `no_match_path`, so removing the key changes no behaviour — it just stops the warning, which would otherwise start showing up in CI logs once `forge test` runs there.

## Verification

Ran the unmodified upstream `Tests` job with this change on a fork branch, end to end:

```
Ran 1 test for src/test/TestSimpleConfidentialToken.t.sol:TestSimpleConfidentialToken
[PASS] testTransfer() (gas: 485969)
Suite result: ok. 1 passed; 0 failed; 0 skipped
```

`forge test` occurrences went 0 → 1, the `test_match` warning is gone, and the rest of the pipeline (`test:e2e`, `test:frontend`, `test:frontend:build`) is unaffected and still green.

## Note

This is why [#41](https://github.com/Inco-fhevm/lightning-rod/pull/41) went unnoticed: a self-transfer in `SimpleConfidentialToken` mints tokens, and the regression test added there only guards the example once CI actually runs the suite. The two changes are independent and can be merged in either order.
