### PR TITLE
docs: add client-side SDK usage to the Inco Lightning walkthrough

### DIFF
--- a/docs/inco-lightning.md
+++ b/docs/inco-lightning.md
@@ -55,6 +55,40 @@ The process for developing a dapp with confidential compute is as follows:
 **Access values by off-chain reencryption**
 - A user that is permitted to access an encrypted handle to a value (mediated by an on-chain access control contract) is able to obtain the decrypted value corresponding to the handle off-chain via a bilateral interaction with our covalidators.
 
+## Client-side usage
 
+The client side of this flow is handled by the `Lightning` client from the Inco Lightning JS SDK. Encrypted inputs are produced with `lightning.encrypt(...)`, and a handle's value is retrieved off-chain with `lightning.attestedDecrypt(...)`, which asks the covalidators to authenticate the request and return the attested plaintext for a wallet-authorized caller.
 
+```typescript
+import { handleTypes } from '@inco/lightning-js';
+import { Lightning } from '@inco/lightning-js/lite';
+import { createWalletClient, http } from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
 
+// Bind to a deployment.
+const lightning = await Lightning.baseSepoliaTestnet();
+
+const account = privateKeyToAccount(privateKey);
+const walletClient = createWalletClient({
+  chain, // a viem Chain for the host chain, e.g. Base Sepolia
+  transport: http(hostChainRpcUrl),
+  account,
+});
+
+// Encrypt an input for a call into the dapp contract.
+const ciphertext = await lightning.encrypt(value, {
+  accountAddress: walletClient.account.address,
+  dappAddress,
+  handleType: handleTypes.euint256,
+});
+
+// ... send `ciphertext` in a transaction to the dapp contract, which returns a `handle` ...
+
+// Reveal the value behind a handle off-chain.
+const decrypted = await lightning.attestedDecrypt(walletClient, [handle]);
+const plaintext = decrypted[0]?.plaintext?.value;
+```
+
+- `Lightning.baseSepoliaTestnet()`, `Lightning.baseMainnet()`, and `Lightning.localNode(pepper)` bind a `Lightning` client to a specific deployment.
+- `lightning.encrypt(value, { accountAddress, dappAddress, handleType })` encrypts a value for a specific dapp contract and returns the ciphertext to submit on-chain. `handleType` comes from `handleTypes`, exported from `@inco/lightning-js`.
+- `lightning.attestedDecrypt(walletClient, [handle])` requests an attested, authenticated decryption of one or more handles from the covalidators and returns an array of results, with each plaintext at `result[0]?.plaintext?.value`. The SDK also supports reencryption modes for callers that need the value re-encrypted rather than returned in plaintext: one returns it re-encrypted for a delegate, and another re-encrypts it for local decryption by the caller.


### PR DESCRIPTION
The SDK walkthrough in `docs/inco-lightning.md` covers the concepts (encrypted inputs, on-chain decryption, off-chain reencryption) but never shows the client-side API a developer actually calls. The two methods every consumer in this repo relies on, `lightning.encrypt(...)` and `lightning.attestedDecrypt(...)`, are not mentioned anywhere in the docs, so a reader following the walkthrough has no path from the concepts to working code.

This adds a short "Client-side usage" section with a minimal example: binding a `Lightning` client to a deployment, encrypting an input for a dapp call, and reading a handle's value with `attestedDecrypt`. The snippet is distilled from this repo's own `react-example` (`backend/src/test/react-example/src/lib/inco.ts`) and the AddTwo e2e test, with the retry/backoff and multi-chain branching removed so the core flow stays clear. Every method, import path, and option in it comes from those files and the `@inco/lightning-js` type definitions.

The change is purely additive. No existing prose or code was modified.

One point for your call: the existing section labels the off-chain mechanism "reencryption", but a plain `attestedDecrypt` call (as used in both reference files) returns an attested plaintext rather than a value re-encrypted under the caller's key. The SDK's own doc-comments separate plaintext results from the two reencryption modes. I kept the new section precise on that distinction and left the existing wording alone. If you would rather tighten the umbrella term, I am happy to fold that in.